### PR TITLE
chore: update builder image to go1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 AS builder
+FROM golang:1.24 AS builder
 WORKDIR /build
 COPY go.mod go.sum /build/
 


### PR DESCRIPTION
## Summary
- use Go 1.24 for builder stage in Dockerfile

## Testing
- `podman build -t minio-test .` *(fails: creating build container: open `/proc/sys/net/ipv4/ping_group_range`: Read-only file system)*
- `go build -v ./cmd/minio-test`


------
https://chatgpt.com/codex/tasks/task_e_68b9303e93948323b45160761b324ba2